### PR TITLE
Fix: Radio text is not centered in the vertical direction when height is changed

### DIFF
--- a/src/widgets/css/check-button.js
+++ b/src/widgets/css/check-button.js
@@ -59,11 +59,11 @@ const SizeCSS: { [key: CheckSize]: TypeSizeCSS } = {
 };
 const getSizeCSS = (props: PropsType): string => {
   const { size = 'default' } = props;
-  const { height, lineHeight } = SizeCSS[size];
+  const { height } = SizeCSS[size];
 
   return `
     height: ${em(height)};
-    line-height: ${em(lineHeight)};
+    line-height: ${em(height)};
   `;
 };
 


### PR DESCRIPTION
Fix: radio text can't be centered when it's height is changed