### PR TITLE
fix:

### DIFF
--- a/src/widgets/new-table/tableCell.js
+++ b/src/widgets/new-table/tableCell.js
@@ -153,11 +153,11 @@ export default class TableCell extends React.Component<TableCellProps, TableCell
     }
   };
 
-  doEnterEditing = (props): void => {
-    const { listener } = this.props;
+  doEnterEditing = (props: Object): void => {
+    const { listener, disableEdit } = this.props;
     const editCell = listener.getEditCell();
     const isCurrentCell = this.isCurrentCell({ editCell });
-    if (!isCurrentCell) {
+    if (!isCurrentCell || disableEdit) {
       return;
     }
 

--- a/src/widgets/new-table/tableCss.js
+++ b/src/widgets/new-table/tableCss.js
@@ -44,6 +44,8 @@ export type TableCellProps = ColumnsType & {
   listener: EditTableEventListenerHandle,
   customRender: ?Function,
   selectSuffixElement: ?Function,
+  selectData: ?Array<{ value: string, text: string }>,
+  allowEdit: boolean,
 };
 
 export type TableCellState = {


### PR DESCRIPTION
    修复可编辑表格在禁止编辑状态下，选中单元格后键盘键入任意值会导致单元格数据消失的问题