### PR TITLE
Fix: Progress use parentNode width while its width is "100%"(当Progress主题宽度传入"100%"时, 使用父节点宽度)

### DIFF
--- a/src/widgets/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/src/widgets/progress/__tests__/__snapshots__/index.test.js.snap
@@ -1628,7 +1628,7 @@ exports[`Progress css 1`] = `
     <p>
       props: percent=
       30
-      active
+      active 
     </p>
     <br />
     <div
@@ -1883,7 +1883,7 @@ exports[`Progress css 1`] = `
     </div>
     <br />
     <p>
-      props: percent=this.state.percent active
+      props: percent=this.state.percent active 
     </p>
     <br />
     <div
@@ -2212,7 +2212,7 @@ exports[`Progress css 1`] = `
       <p>
         props: size=small percent=
         30
-         active
+         active 
       </p>
       <br />
       <div

--- a/src/widgets/progress/circle.js
+++ b/src/widgets/progress/circle.js
@@ -38,6 +38,7 @@ export default class extends React.Component<any, any> {
 
   componentDidMount() {
     if (this.shouldSecondRender) {
+      this.shouldSecondRender = false;
       this.setState({ secondRender: Math.random() });
     }
   }

--- a/src/widgets/progress/circle.js
+++ b/src/widgets/progress/circle.js
@@ -24,9 +24,22 @@ function getPolyLine(radius: number, strokeWidth: number, cnt: number, stroke: s
 }
 
 export default class extends React.Component<any, any> {
+  circleProgress: Object;
+  shouldSecondRender: boolean;
+
   constructor(props) {
     super(props);
     this.circleProgress = React.createRef();
+    this.shouldSecondRender = false;
+    this.state = {
+      secondRender: 0,
+    };
+  }
+
+  componentDidMount() {
+    if (this.shouldSecondRender) {
+      this.setState({ secondRender: Math.random() });
+    }
   }
 
   render() {
@@ -152,6 +165,8 @@ export default class extends React.Component<any, any> {
       const { offsetWidth = 0 } = this.circleProgress.current.parentNode;
       return offsetWidth;
     }
+    this.shouldSecondRender = true;
+
     return 0;
   };
 

--- a/src/widgets/progress/circle.js
+++ b/src/widgets/progress/circle.js
@@ -140,10 +140,11 @@ export default class extends React.Component<any, any> {
 
   whetherWidthIsPercent = (value: string | number) => {
     if (!value && value !== 0) return;
-    const reg = /^\d+%$/; // 判断宽度是否是百分比
+    const reg = /^\d+%$/;
     return reg.test(value);
   };
   getParentNodeWidth = () => {
+    if (!this.circleProgress) return;
     if (this.circleProgress.current && this.circleProgress.current.parentNode) {
       const { offsetWidth = 0 } = this.circleProgress.current.parentNode;
       return offsetWidth;

--- a/src/widgets/progress/circle.js
+++ b/src/widgets/progress/circle.js
@@ -113,7 +113,8 @@ export default class extends React.Component<any, any> {
     } = svgInnerTheme;
     const { size = 'default' } = this.props;
     const isDefault = size === 'default';
-    const halfWidth = this.whetherWidthIsPercent(width) ? this.getParentNodeWidth() / 2 : width / 2;
+    const finalWidth = this.getFinalWidth(width);
+    const halfWidth = finalWidth / 2;
     const cxOrCy = width ? halfWidth : isDefault ? 60 : 40;
     const borderWidth = topWidth || rightWidth || bottomWidth || leftWidth;
     const strokeWidth = borderWidth || circleWidth || (isDefault ? 8 : 6);
@@ -131,25 +132,27 @@ export default class extends React.Component<any, any> {
       strokeWidth,
       circleLength,
       transform: width
-        ? `matrix(0,-1,1,0,0,${width})`
+        ? `matrix(0,-1,1,0,0,${finalWidth})`
         : isDefault
         ? 'matrix(0,-1,1,0,0,120)'
         : 'matrix(0,-1,1,0,0,80)',
     };
   };
 
+  getFinalWidth = (value: string | number): number => {
+    return this.whetherWidthIsPercent(value) ? this.getParentNodeWidth() : value;
+  };
   whetherWidthIsPercent = (value: string | number) => {
     if (!value && value !== 0) return;
     const reg = /^\d+%$/;
     return reg.test(value);
   };
   getParentNodeWidth = () => {
-    if (!this.circleProgress) return;
     if (this.circleProgress.current && this.circleProgress.current.parentNode) {
       const { offsetWidth = 0 } = this.circleProgress.current.parentNode;
       return offsetWidth;
     }
-    return 120;
+    return 0;
   };
 
   getPercentText = () => {

--- a/src/widgets/progress/circle.js
+++ b/src/widgets/progress/circle.js
@@ -24,6 +24,11 @@ function getPolyLine(radius: number, strokeWidth: number, cnt: number, stroke: s
 }
 
 export default class extends React.Component<any, any> {
+  constructor(props) {
+    super(props);
+    this.circleProgress = React.createRef();
+  }
+
   render() {
     const {
       percent = 0,
@@ -59,7 +64,7 @@ export default class extends React.Component<any, any> {
     const lineColor = this.getLineColor(lineTheme);
 
     return (
-      <SvgInner size={size} themeProps={svgInnerTheme}>
+      <SvgInner size={size} themeProps={svgInnerTheme} ref={this.circleProgress}>
         {type === 'circle' ? (
           <CircleWrap>
             <circle {...config} stroke={backgroundLineColor} />
@@ -108,7 +113,7 @@ export default class extends React.Component<any, any> {
     } = svgInnerTheme;
     const { size = 'default' } = this.props;
     const isDefault = size === 'default';
-    const halfWidth = width / 2;
+    const halfWidth = this.whetherWidthIsPercent(width) ? this.getParentNodeWidth() / 2 : width / 2;
     const cxOrCy = width ? halfWidth : isDefault ? 60 : 40;
     const borderWidth = topWidth || rightWidth || bottomWidth || leftWidth;
     const strokeWidth = borderWidth || circleWidth || (isDefault ? 8 : 6);
@@ -132,6 +137,20 @@ export default class extends React.Component<any, any> {
         : 'matrix(0,-1,1,0,0,80)',
     };
   };
+
+  whetherWidthIsPercent = (value: string | number) => {
+    if (!value && value !== 0) return;
+    const reg = /^\d+%$/; // 判断宽度是否是百分比
+    return reg.test(value);
+  };
+  getParentNodeWidth = () => {
+    if (this.circleProgress.current && this.circleProgress.current.parentNode) {
+      const { offsetWidth = 0 } = this.circleProgress.current.parentNode;
+      return offsetWidth;
+    }
+    return 120;
+  };
+
   getPercentText = () => {
     const {
       percent = 0,


### PR DESCRIPTION
Fix: Progress use parentNode width while its width is "100%"(当Progress主题宽度传入"100%"时, 内部使用父节点宽度做处理)

