### PR TITLE
Fix: keep same with rich-editor in design(基本样式与design中富文本编辑器保持一致)

### DIFF
--- a/src/widgets/rich-text/index.js
+++ b/src/widgets/rich-text/index.js
@@ -47,7 +47,11 @@ const LabelContainer = CSSComponent({
   css: css`
     display: inline-block;
     box-sizing: border-box;
-    white-space: pre;
+    line-height: 1.4;
+    font-size: 14px;
+    font-family: sans-serif !important;
+    white-space: normal;
+    word-break: break-word;
   `,
   option: { hover: true },
 });


### PR DESCRIPTION
Fix: keep same with rich-editor in design(基本样式与design中富文本编辑器保持一致)